### PR TITLE
fix case where open and close are equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function pixie (source, open, close) {
     first = source.indexOf(open)
     if (first < 0) break
     partials.push(source.slice(0, first))
-    last = source.indexOf(close, first)
+    last = source.indexOf(close, first + openLength)
     expressions.push(source.slice(first + openLength, last))
     source = source.slice(last + closeLength)
   }

--- a/test.js
+++ b/test.js
@@ -4,11 +4,12 @@ var compile = pixie.compile
 var render = pixie.render
 
 test('parse', function (t) {
-  t.plan(4)
+  t.plan(5)
   t.same(pixie('foo{{bar}}baz{{qux}}qix'), [['foo', 'baz', 'qix',], ['bar', 'qux']], 'inner expressions')
   t.same(pixie('{{foo}}bar{{baz}}qux{{qix}}'), [['', 'bar', 'qux', ''], ['foo', 'baz', 'qix']], 'outer expressions')
   t.same(pixie('foo bar baz qux qix'), [['foo bar baz qux qix'], []], 'no expressions')
   t.same(pixie('foo <%bar%> baz <%qux%>', '<%', '%>'), [['foo ', ' baz ', ''], ['bar', 'qux']], 'custom tags')
+  t.same(pixie('foo __bar__ baz __qux__', '__', '__'), [['foo ', ' baz ', ''], ['bar', 'qux']], 'custom tags with same open and close')
 })
 
 test('compile', function (t) {


### PR DESCRIPTION
hey,

my use case is to have templates that are valid code, so it's less of a pain to keep them in sync. the best open and close i've come up with so far for this is `__` and `__`, which needs this fix to run.

cheers!